### PR TITLE
add redis rmp builder

### DIFF
--- a/redis/Dockerfile.base
+++ b/redis/Dockerfile.base
@@ -1,0 +1,8 @@
+FROM photon:4.0
+
+COPY ./redis-debuginfo-6.0.15-1.ph4.aarch64.rpm /redis/
+COPY ./redis-6.0.15-1.ph4.aarch64.rpm /redis/
+
+RUN tdnf install -y /redis/redis-debuginfo-6.0.15-1.ph4.aarch64.rpm /redis/redis-6.0.15-1.ph4.aarch64.rpm >> /dev/null \
+    && rm -rf /redis \
+    && tdnf clean all

--- a/redis/redis.spec
+++ b/redis/redis.spec
@@ -1,0 +1,89 @@
+Summary:        advanced key-value store
+Name:           redis
+Version:        6.0.15
+Release:        1%{?dist}
+License:        BSD
+URL:            http://redis.io/
+Group:          Applications/Databases
+Vendor:         VMware, Inc.
+Distribution:   Photon
+Source0:        http://download.redis.io/releases/%{name}-%{version}.tar.gz
+%define sha1 redis=432a1fd3b45ee2f35fa9f9db57514b490b8c4724
+Patch0:         redis-conf.patch
+BuildRequires:  gcc
+BuildRequires:  systemd
+BuildRequires:  make
+BuildRequires:  which
+BuildRequires:  tcl
+BuildRequires:  tcl-devel
+BuildRequires:  procps-ng
+Requires:       systemd
+Requires(pre):  /usr/sbin/useradd /usr/sbin/groupadd
+
+%description
+Redis is an in-memory data structure store, used as database, cache and message broker.
+
+%prep
+%autosetup -p1
+
+%build
+grep -F 'cd jemalloc && ./configure ' ./deps/Makefile
+sed -ri 's!cd jemalloc && ./configure !&'"--with-lg-page=16 --with-lg-hugepage=21"' !' ./deps/Makefile
+grep -F "cd jemalloc && ./configure --with-lg-page=16 --with-lg-hugepage=21 " ./deps/Makefile;
+make %{?_smp_mflags}
+
+%install
+install -vdm 755 %{buildroot}
+make PREFIX=%{buildroot}/usr install %{?_smp_mflags}
+install -D -m 0640 %{name}.conf %{buildroot}%{_sysconfdir}/%{name}.conf
+mkdir -p %{buildroot}/var/lib/redis
+mkdir -p %{buildroot}/var/log
+mkdir -p %{buildroot}/var/opt/%{name}/log
+ln -sfv /var/opt/%{name}/log %{buildroot}/var/log/%{name}
+mkdir -p %{buildroot}/usr/lib/systemd/system
+cat << EOF >>  %{buildroot}/usr/lib/systemd/system/redis.service
+[Unit]
+Description=Redis in-memory key-value database
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/redis-server /etc/redis.conf --daemonize no
+ExecStop=/usr/bin/redis-cli shutdown
+User=redis
+Group=redis
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+%check
+#make check %{?_smp_mflags}
+
+%pre
+getent group %{name} &> /dev/null || \
+groupadd -r %{name} &> /dev/null
+getent passwd %{name} &> /dev/null || \
+useradd -r -g %{name} -d %{_sharedstatedir}/%{name} -s /sbin/nologin \
+-c 'Redis Database Server' %{name} &> /dev/null
+exit 0
+
+%post
+/sbin/ldconfig
+%systemd_post  redis.service
+
+%postun
+/sbin/ldconfig
+%systemd_postun_with_restart redis.service
+
+%files
+%defattr(-,root,root)
+%dir %attr(0750, redis, redis) /var/lib/redis
+%dir %attr(0750, redis, redis) /var/opt/%{name}/log
+%attr(0750, redis, redis) %{_var}/log/%{name}
+%{_bindir}/*
+%{_libdir}/systemd/*
+%config(noreplace) %attr(0640, %{name}, %{name}) %{_sysconfdir}/redis.conf
+
+%changelog
+*   Yan Wang <wangyan@vmware.com>
+-   Customize redis from original spec

--- a/redis/rpm_builder.sh
+++ b/redis/rpm_builder.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -e
+
+name='redis'
+version='6.0.15'
+core_branch='release-2.3.0'
+
+function checkdep {
+	if ! wget --version &> /dev/null
+	then
+		echo "Need to install wget first and run this script again."
+		exit 1
+	fi
+}
+
+checkdep
+
+cur=$PWD
+workDir=`mktemp -d ${TMPDIR-/tmp}/$name.XXXXXX`
+mkdir -p $workDir && cd $workDir
+
+# step 1: get source code of redis
+wget http://download.redis.io/releases/$name-$version.tar.gz
+
+# step 2: get redis-conf.patch from upstream
+wget https://raw.githubusercontent.com/vmware/photon/4.0/SPECS/redis/redis-conf.patch
+
+# step 3: get spec builder script, and replace version to 4, then to build the redis rpm packages
+wget https://raw.githubusercontent.com/vmware/photon/4.0/tools/scripts/build_spec.sh
+sed "s|VERSION=3|VERSION=4|g" -i build_spec.sh
+chmod 655 ./build_spec.sh && cp $cur/redis.spec .
+
+# step 4: build redis rpm.
+./build_spec.sh ./redis.spec
+cp ./stage/RPMS/aarch64/$name-debuginfo-$version-1.ph4.aarch64.rpm $cur
+cp ./stage/RPMS/aarch64/$name-$version-1.ph4.aarch64.rpm $cur
+
+# clean
+cd $cur && rm -rf $workDir


### PR DESCRIPTION
In the arm env, redis needs to set the --with-lg-page=16 --with-lg-hugepage=21 when to build jemalloc
For details, needs to refer to: docker-library/redis#254

Note:
1. The rmp build must be executed on an arm based environment.
2. The make check in the redis source is disabled as the new parameters will fail the jemalloc test, it needs more investigation.

Signed-off-by: Wang Yan <wangyan@vmware.com>