### PR TITLE
add harbor arm base image build step

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,10 @@ make pre_update
 # Compile harbor components:
 make compile COMPILETAG=compile_golangimage
 
+# Build harbor arm base image:
+make build_base_image
+
 # Build harbor arm image:
 make build GOBUILDTAGS="include_oss include_gcs" BUILDBIN=true NOTARYFLAG=true TRIVYFLAG=true CHARTFLAG=true GEN_TLS=true PULL_BASE_FROM_DOCKERHUB=false
 
-
 ```
-
-
-
-
-


### PR DESCRIPTION
add step to build base image because there isn't base image in DOCKERHUB.